### PR TITLE
fix(latexheader.tex): workaround to get rid of red boxes in pygments

### DIFF
--- a/latexheader.tex
+++ b/latexheader.tex
@@ -40,6 +40,9 @@
 }
 \expandafter\makenewmintedfiles\expandafter{\args}
 
+%workaround to remove red boxes
+\AtBeginEnvironment{minted}{\renewcommand{\fcolorbox}[4][]{#4}}
+
 % Colors, links, syntax highlighting
 \usepackage[dvipsnames,table]{xcolor}
 \hypersetup{


### PR DESCRIPTION
Currently, there are red boxes around symbols not recognized by the minted/pygments lexer.