### PR TITLE
fix(index.html,header/html.org): fix javascript errors in mobile safari ios10

### DIFF
--- a/header/html.org
+++ b/header/html.org
@@ -2,5 +2,5 @@
 #+OPTIONS: html-postamble:nil
 #+HTML_HEAD_EXTRA:<link rel="stylesheet" href="css/tutorial.css"/>
 #+HTML_HEAD_EXTRA:<link rel="stylesheet" href="css/code.css"/>
-#+HTML_HEAD_EXTRA:<script type="text/javascript" charset="utf-8">if(!window.PolymerGestures) { var head = document.getElementsByTagName('head')[0]; var js = document.createElement("script"); js.type = "text/javascript"; js.src = "//cdn.jsdelivr.net/webcomponentsjs/0.7.20/webcomponents.min.js"; head.appendChild(js); } </script>
+#+HTML_HEAD_EXTRA:<script type="text/javascript" charset="utf-8">if(!window.PolymerGestures) { var head = document.getElementsByTagName('head')[0]; var js = document.createElement("script"); js.type = "text/javascript"; js.src = "//cdn.jsdelivr.net/webcomponentsjs/0.7.23/webcomponents.min.js"; head.appendChild(js); } </script>
 #+HTML_HEAD_EXTRA:<link rel='import' href='juicy-ace-editor.html'/>

--- a/index.html
+++ b/index.html
@@ -61,9 +61,9 @@
         <button id="close_setting_window">Close</button>
       </div>
     </div>
-    <script src="//cdn.jsdelivr.net/webcomponentsjs/0.7.20/webcomponents.min.js"></script>
     <script src="//cdn.jsdelivr.net/jquery/2.1.4/jquery.min.js"></script>
     <script src="//cdn.jsdelivr.net/jquery.cookie/1.4.1/jquery.cookie.min.js"></script>
+    <script src="//cdn.jsdelivr.net/webcomponentsjs/0.7.23/webcomponents.min.js"></script>
     <script src="//leanprover.github.io/ace/ace/ace.js" type="text/javascript" charset="utf-8"></script>
     <script src="//leanprover.github.io/ace/ace/ext-language_tools.js" type="text/javascript" charset="utf-8"></script>
     <script src="js/input-method.js" type="text/javascript" charset="utf-8"></script>


### PR DESCRIPTION
Same changes I made to the "tutorial" repo, which is probably just an instance of this mkleanbook repo: https://github.com/leanprover/tutorial/commit/59dcf6140ce06813f5bee068e15fd1f97f082310